### PR TITLE
fix(GUIDEFRAME-37): Adjust output name in workflow

### DIFF
--- a/.github/workflows/render.yaml
+++ b/.github/workflows/render.yaml
@@ -37,4 +37,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: tutors-test
-        path: ./final_output.mp4
+        path: ./tutors_test*.mp4


### PR DESCRIPTION
* Adjust naming in the tutors-test workflow to match script name.
* Wildcard used to account for the UUID in the names.